### PR TITLE
Lower minSdk to 31 to support Android 12

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 
   defaultConfig {
     applicationId = "dev.thomasbuilds.spectre"
-    minSdk = 33
+    minSdk = 31
     targetSdk = 37
     versionCode = appVersionCode
     versionName = appVersionName

--- a/app/src/main/java/dev/thomasbuilds/spectre/MainActivity.kt
+++ b/app/src/main/java/dev/thomasbuilds/spectre/MainActivity.kt
@@ -62,7 +62,10 @@ class MainActivity : ComponentActivity() {
       add(Manifest.permission.BLUETOOTH_SCAN)
       add(Manifest.permission.BLUETOOTH_CONNECT)
       add(Manifest.permission.BLUETOOTH_ADVERTISE)
-      add(Manifest.permission.POST_NOTIFICATIONS)
+      // POST_NOTIFICATIONS is a runtime permission only on Android 13+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        add(Manifest.permission.POST_NOTIFICATIONS)
+      }
       // ACCESS_LOCAL_NETWORK is the runtime permission introduced in Android 16 that gates LAN
       // access (including WifiInfo.bssid for the Connected label, mDNS, SSDP, and unicast TCP).
       // Mandatory on Android 17 for apps targeting SDK 37+.

--- a/app/src/main/java/dev/thomasbuilds/spectre/scanner/ble/GattInspector.kt
+++ b/app/src/main/java/dev/thomasbuilds/spectre/scanner/ble/GattInspector.kt
@@ -13,6 +13,7 @@ import android.bluetooth.BluetoothProfile
 import android.bluetooth.BluetoothStatusCodes
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.compose.runtime.Immutable
@@ -194,6 +195,17 @@ class GattInspector(
           mainHandler.post { s.onRead(uuid, value, status) }
         }
 
+        @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+        override fun onCharacteristicRead(
+          g: BluetoothGatt,
+          characteristic: BluetoothGattCharacteristic,
+          status: Int
+        ) {
+          val uuid = characteristic.uuid.toString()
+          val value = characteristic.value ?: ByteArray(0)
+          mainHandler.post { s.onRead(uuid, value, status) }
+        }
+
         override fun onCharacteristicWrite(
           g: BluetoothGatt,
           characteristic: BluetoothGattCharacteristic,
@@ -289,17 +301,36 @@ class GattInspector(
         BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
       }
     pendingWrite = onResult
-    val code =
-      runCatching { g.writeCharacteristic(characteristic, value, writeType) }
-        .getOrElse {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      val code =
+        runCatching { g.writeCharacteristic(characteristic, value, writeType) }
+          .getOrElse {
+            pendingWrite = null
+            onResult(false, "Write threw: ${it.message}")
+            return
+          }
+      if (code != BluetoothStatusCodes.SUCCESS) {
+        pendingWrite = null
+        onResult(false, "Write rejected (code $code)")
+        return
+      }
+    } else {
+      @Suppress("DEPRECATION")
+      val ok =
+        runCatching {
+          characteristic.writeType = writeType
+          characteristic.value = value
+          g.writeCharacteristic(characteristic)
+        }.getOrElse {
           pendingWrite = null
           onResult(false, "Write threw: ${it.message}")
           return
         }
-    if (code != BluetoothStatusCodes.SUCCESS) {
-      pendingWrite = null
-      onResult(false, "Write rejected (code $code)")
-      return
+      if (!ok) {
+        pendingWrite = null
+        onResult(false, "Write rejected")
+        return
+      }
     }
     mainHandler.postDelayed({
       if (pendingWrite === onResult) {

--- a/app/src/main/java/dev/thomasbuilds/spectre/scanner/wifi/WifiScanner.kt
+++ b/app/src/main/java/dev/thomasbuilds/spectre/scanner/wifi/WifiScanner.kt
@@ -11,6 +11,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.wifi.ScanResult
 import android.net.wifi.WifiManager
+import android.os.Build
 import androidx.core.content.ContextCompat
 import dev.thomasbuilds.spectre.analysis.Distance
 import dev.thomasbuilds.spectre.model.DetailEntry
@@ -269,7 +270,7 @@ class WifiScanner(
     val generation = scanGeneration.incrementAndGet()
 
     results.forEach { sr ->
-      val key = (sr.BSSID ?: "").ifEmpty { sr.wifiSsid?.toString().orEmpty() }
+      val key = (sr.BSSID ?: "").ifEmpty { sr.ssidString() }
       if (key.isEmpty()) return@forEach
 
       val sanitized = sanitizeRssi(sr.level)
@@ -333,11 +334,7 @@ class WifiScanner(
   ): WifiSignal {
     val freq = sr.frequency
     val band = WifiChannels.bandFor(freq)
-    val rawSsid =
-      sr.wifiSsid
-        ?.toString()
-        ?.trim('"')
-        .orEmpty()
+    val rawSsid = sr.ssidString().trim('"')
     val ssid = if (rawSsid.isBlank()) "Hidden" else rawSsid
     val width = WifiChannels.widthMhz(sr.channelWidth)
     val channel = WifiChannels.channelNumber(freq)
@@ -389,6 +386,14 @@ class WifiScanner(
     if (raw == Int.MIN_VALUE || raw >= 0) return null
     return raw
   }
+
+  @Suppress("DEPRECATION")
+  private fun ScanResult.ssidString(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      wifiSsid?.toString().orEmpty()
+    } else {
+      SSID.orEmpty()
+    }
 
   private companion object {
     const val EMA_ALPHA = 0.3


### PR DESCRIPTION
Supporting Android 12 is a small change that does not worsen code quality so lowering minSdk to 31 is the right move.

@TheoBohard I've seen you suggested similar changes in your fork so I added you as co-author on the commit.
Some users cannot install the app so given the urgency I can't wait for you to open a PR and credited you directly instead.
Let me know if anything looks wrong with this approach, but it should be good.