### PR TITLE
Fix notification for app exit on Android 12

### DIFF
--- a/app/src/main/java/dev/thomasbuilds/spectre/service/RFMonitorService.kt
+++ b/app/src/main/java/dev/thomasbuilds/spectre/service/RFMonitorService.kt
@@ -358,10 +358,16 @@ class RFMonitorService : Service() {
       .Builder(this, channelId)
       .setSmallIcon(R.drawable.ic_notification)
       .setContentTitle(title)
-      .setContentText("Swipe to close app")
       .setContentIntent(pi)
       .setDeleteIntent(shutdownPi)
-      .setOngoing(false)
+      .apply {
+        // The notification can't be swiped away before Android 13
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          setContentText("Swipe to close app")
+        } else {
+          addAction(0, "Stop measuring", shutdownPi)
+        }
+      }.setOngoing(false)
       .setShowWhen(false)
       .setPriority(NotificationCompat.PRIORITY_DEFAULT)
       .setSilent(true)
@@ -370,8 +376,7 @@ class RFMonitorService : Service() {
   }
 
   private fun refreshNotification() {
-    val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-    nm.notify(NOTIFICATION_ID, buildNotification())
+    if (startedForeground) startInForeground()
   }
 
   private fun startInForeground(): Boolean =


### PR DESCRIPTION
The foreground-service notification can't be swiped away before Android 13, so the "Swipe to close app" hint was a dead end on Android 12/12L with no other way to exit the app. Show a Stop measuring action there instead, and keep the hint only where swiping works. Post updates through startForeground rather than notify(): notify() strips the foreground-service flag from the record, letting the notification outlive the service on non-swipe stop paths.

Fixes #27 